### PR TITLE
ON-4256 | Avoid trying to create a redirect to itself

### DIFF
--- a/lib/services/publish.js
+++ b/lib/services/publish.js
@@ -62,6 +62,12 @@ function addRedirects(metaObj, uri) {
       newUri = `${newUrl.hostname}${newUrl.pathname}`,
       prefix = getPrefix(uri);
 
+    // public.uris has a constraint that prevents adding a redirect to itself.
+    // Catch this here to avoid triggering an exception.
+    if (prevUri === newUri) {
+      return metaObj;
+    }
+
     // update the previous uri to point to the latest uri
     return db.put(`${prefix}/_uris/${buf.encode(prevUri)}`, `${prefix}/_uris/${buf.encode(newUri)}`)
       .then(() => metaObj);


### PR DESCRIPTION
`public.uris` table has a constraint to prevent adding a redirect to itself, but this throws an error. Catch this condition in code so we can avoid the exception.