### PR TITLE
ON-3831 | Move redirect add to the end of the publish process

### DIFF
--- a/lib/services/pages.js
+++ b/lib/services/pages.js
@@ -276,14 +276,16 @@ function publish(uri, data, locals) {
     })
     .timeout(timeoutLimit, `Page publish exceeded ${timeoutLimit}ms: ${uri}`)
     .then(publishedData => {
-      return meta.publishPage(uri, publishedMeta, user).then(() => {
-        // Notify the bus
-        bus.publish('publishPage', { uri, data: publishedData, user});
+      return meta.publishPage(uri, publishedMeta, user)
+        .then(() => publishService.addRedirects(publishedMeta, uri))
+        .then(() => {
+          // Notify the bus
+          bus.publish('publishPage', { uri, data: publishedData, user});
 
-        notifications.notify(site, 'published', publishedData);
-        // Update the meta object
-        return publishedData;
-      });
+          notifications.notify(site, 'published', publishedData);
+          // Update the meta object
+          return publishedData;
+        });
     });
 }
 

--- a/lib/services/publish.js
+++ b/lib/services/publish.js
@@ -171,7 +171,6 @@ function publishPageAtUrl(url, uri, data, locals, site) { // eslint-disable-line
 
   return bluebird.resolve({ url })
     .then(metaObj => storeUrlHistory(metaObj, uri, url))
-    .then(metaObj => addRedirects(metaObj, uri))
     .then(metaObj => addToMeta(metaObj, site.assignToMetaOnPublish, uri, data));
 }
 
@@ -267,5 +266,6 @@ module.exports._checkForArchived = _checkForArchived;
 module.exports.processPublishRules = processPublishRules;
 module.exports.validatePublishRules = validatePublishRules;
 module.exports.addToMeta = addToMeta;
+module.exports.addRedirects = addRedirects;
 module.exports.setLog = mock => log = mock;
 module.exports.setDb = mock => db = mock;


### PR DESCRIPTION
Moves `addRedirects` to the 2nd to last step in the publishing process instead of somewhere in the middle